### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Classes (KEYWORD1)
 ###########################################################
 
-RTC		KEYWORD1
+RTC	KEYWORD1
 
 ###########################################################
 # Datatypes (KEYWORD1)
@@ -18,18 +18,18 @@ DateTime	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ###########################################################
 
-year		KEYWORD2
-month		KEYWORD2
-day		KEYWORD2
-hour		KEYWORD2
-minute		KEYWORD2
-second		KEYWORD2
+year	KEYWORD2
+month	KEYWORD2
+day	KEYWORD2
+hour	KEYWORD2
+minute	KEYWORD2
+second	KEYWORD2
 dayOfWeek	KEYWORD2
 unixtime	KEYWORD2
-begin		KEYWORD2
+begin	KEYWORD2
 setDateTime	KEYWORD2
 getDateTime	KEYWORD2
-isReady		KEYWORD2
+isReady	KEYWORD2
 dateFormat	KEYWORD2
 
 ###########################################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords