### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,31 +6,31 @@
 # Classes (KEYWORD1)
 ###########################################################
 
-RTC KEYWORD1
+RTC	KEYWORD1
 
 ###########################################################
 # Datatypes (KEYWORD1)
 ###########################################################
 
-DateTime  KEYWORD1
+DateTime	KEYWORD1
 
 ###########################################################
 # Methods and Functions (KEYWORD2)
 ###########################################################
 
-year  KEYWORD2
-month KEYWORD2
-day KEYWORD2
-hour  KEYWORD2
-minute  KEYWORD2
-second  KEYWORD2
-dayOfWeek KEYWORD2
-unixtime  KEYWORD2
-begin KEYWORD2
-setDateTime KEYWORD2
-getDateTime KEYWORD2
-isReady KEYWORD2
-dateFormat  KEYWORD2
+year	KEYWORD2
+month	KEYWORD2
+day	KEYWORD2
+hour	KEYWORD2
+minute	KEYWORD2
+second	KEYWORD2
+dayOfWeek	KEYWORD2
+unixtime	KEYWORD2
+begin	KEYWORD2
+setDateTime	KEYWORD2
+getDateTime	KEYWORD2
+isReady	KEYWORD2
+dateFormat	KEYWORD2
 
 ###########################################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords